### PR TITLE
Update "RootDocumentId" used for hiding document

### DIFF
--- a/src/openapi/I_Test_Driver_FdV.yaml
+++ b/src/openapi/I_Test_Driver_FdV.yaml
@@ -2615,9 +2615,9 @@ components:
       example: 'urn:uuid:4fa70820-2384-4001-80a9-7bbd5e085efb'
     RootDocumentIdType:
       description: |
-        A CXi style identifier with schema 'uniqueID^^^^urn:gematik:iti:xds:2023:rootDocumentUniqueId' with symbolic UUID as uniqueId
+        A CXi style identifier with schema 'uniqueID' with symbolic UUID as uniqueId
       type: string
-      example: '4fa70820-2384-4001-80a9-7bbd5e085efb^^^^urn:gematik:iti:xds:2023:rootDocumentUniqueId'
+      example: '4fa70820-2384-4001-80a9-7bbd5e085efb'
     AssignmentIdType:
       description: Server-assigned unique uuid of a particular deny policy assignment
       type: string


### PR DESCRIPTION
The current value for RootDocumentId = 'uniqueID^^^^urn:gematik:iti:xds:2023:rootDocumentUniqueId' which maps to "uniqueID + ihe-coding" , doesn't work to set a new assignment for a deny policy. This is not supported by SDK, since SDK is doing the ihe-coding internally for FdV to avoid unnecessary errors. Hence may I suggest on RISE behalf to update the "rootDocumentId" value to be only the "UniqueID" or the "referenceIdList"